### PR TITLE
Add color palette CSS variables for theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,30 @@
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
+	/* Palette: Primary */
+	--color-primary-100: var(--primary-blue-100);
+	--color-primary-300: var(--primary-blue-300);
+	--color-primary-500: var(--primary-blue-500);
+	--color-primary-600: var(--primary-blue-600);
+	--color-primary-700: var(--primary-blue-700);
+	--color-primary-900: var(--primary-blue-900);
+	/* Palette: Secondary */
+	--color-secondary-500: var(--secondary-teal-500);
+	--color-secondary-700: var(--secondary-teal-700);
+	/* Palette: Accent */
+	--color-accent-purple-500: var(--accent-purple-500);
+	--color-accent-orange-500: var(--accent-orange-500);
+	/* Palette: Neutral */
+	--color-neutral-100: var(--neutral-gray-100);
+	--color-neutral-200: var(--neutral-gray-200);
+	--color-neutral-300: var(--neutral-gray-300);
+	--color-neutral-700: var(--neutral-gray-700);
+	--color-neutral-900: var(--neutral-gray-900);
+	/* Palette: Feedback */
+	--color-feedback-success: var(--feedback-success);
+	--color-feedback-warning: var(--feedback-warning);
+	--color-feedback-error: var(--feedback-error);
+	--color-feedback-info: var(--feedback-info);
 }
 
 :root {
@@ -74,6 +98,30 @@
 	--sidebar-accent-foreground: oklch(0.205 0 0);
 	--sidebar-border: oklch(0.922 0 0);
 	--sidebar-ring: oklch(0.708 0 0);
+	/* Palette: Primary */
+	--primary-blue-100: #e6f0fa;
+	--primary-blue-300: #80bfff;
+	--primary-blue-500: #1e90ff;
+	--primary-blue-600: #2563eb;
+	--primary-blue-700: #1565c0;
+	--primary-blue-900: #0d47a1;
+	/* Palette: Secondary */
+	--secondary-teal-500: #009688;
+	--secondary-teal-700: #00695c;
+	/* Palette: Accent */
+	--accent-purple-500: #7e57c2;
+	--accent-orange-500: #ff9800;
+	/* Palette: Neutral */
+	--neutral-gray-100: #f5f5f5;
+	--neutral-gray-200: #ffffff;
+	--neutral-gray-300: #e0e0e0;
+	--neutral-gray-700: #616161;
+	--neutral-gray-900: #212121;
+	/* Palette: Feedback */
+	--feedback-success: #4caf50;
+	--feedback-warning: #ffc107;
+	--feedback-error: #f44336;
+	--feedback-info: #2196f3;
 }
 
 .dark {
@@ -108,6 +156,30 @@
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	--sidebar-border: oklch(1 0 0 / 10%);
 	--sidebar-ring: oklch(0.556 0 0);
+	/* Palette: Primary */
+	--primary-blue-100: #e6f0fa;
+	--primary-blue-300: #80bfff;
+	--primary-blue-500: #1e90ff;
+	--primary-blue-600: #2563eb;
+	--primary-blue-700: #1565c0;
+	--primary-blue-900: #0d47a1;
+	/* Palette: Secondary */
+	--secondary-teal-500: #009688;
+	--secondary-teal-700: #00695c;
+	/* Palette: Accent */
+	--accent-purple-500: #7e57c2;
+	--accent-orange-500: #ff9800;
+	/* Palette: Neutral */
+	--neutral-gray-100: #f5f5f5;
+	--neutral-gray-200: #ffffff;
+	--neutral-gray-300: #e0e0e0;
+	--neutral-gray-700: #616161;
+	--neutral-gray-900: #212121;
+	/* Palette: Feedback */
+	--feedback-success: #4caf50;
+	--feedback-warning: #ffc107;
+	--feedback-error: #f44336;
+	--feedback-info: #2196f3;
 }
 
 @layer base {


### PR DESCRIPTION
Introduced new CSS variables for primary, secondary, accent, neutral, and feedback color palettes in both light and dark themes. This centralizes color management and improves maintainability and consistency across the application's styles.